### PR TITLE
Add support for 12+ population bracket. 

### DIFF
--- a/post_covid_stats.py
+++ b/post_covid_stats.py
@@ -102,7 +102,7 @@ def normalise_vax_data_for_population(data: Dict, population_bracket: str):
         youthFullVax: int = int(data["VACC_PEOPLE_CNT_12_15"])
 
         # fallback on previous vax if 0. Datafeed seems to update current vax with 
-        # yesterdays data but not 12-15, so this should be accurate (enough)
+        # yesterdays data before todays data comes in but not 12-15, so this should be accurate (enough)
         if youthFirstVax == 0:
             youthFirstVax = int(data["PREV_VACC_FIRST_DOSE_CNT_12_15"])
 

--- a/resources/state-data.json
+++ b/resources/state-data.json
@@ -2,54 +2,63 @@
   "AUS": {
     "EMOJI": "flag-au",
     "POPULATION": {
+      "12+": 21863949,
       "16+": 20619959
     }
   },
   "ACT": {
     "EMOJI": "ballot_box_with_ballot",
     "POPULATION": {
+      "12+": 363730,
       "16+": 344037
     }
   },
   "NSW": {
     "EMOJI": "beach_with_umbrella",
     "POPULATION": {
+      "12+": 6955981,
       "16+": 6565651
     }
   },
   "NT": {
     "EMOJI": "kangaroo",
     "POPULATION": {
+      "12+": 203631,
       "16+": 190571
     }
   },
   "QLD": {
     "EMOJI": "thong_sandal",
     "POPULATION": {
+      "12+": 4382853,
       "16+": 4112707
     }
   },
   "SA": {
     "EMOJI": "wine-glass",
     "POPULATION": {
+      "12+": 1523147,
       "16+": 1440400
     }
   },
   "TAS": {
     "EMOJI": "smiling_imp",
     "POPULATION": {
+      "12+": 466480,
       "16+": 440172
     }
   },
   "VIC": {
     "EMOJI": "coffee",
     "POPULATION": {
+      "12+": 5716185,
       "16+": 5407574
     }
   },
   "WA": {
     "EMOJI": "hamster",
     "POPULATION": {
+      "12+": 2247847,
       "16+": 2114978
     }
   }


### PR DESCRIPTION
Allows vax stats to report 12+ population now, also removes the 12-15 jabs from the 16+ count to ensure accurate green ticks and calculations.